### PR TITLE
Build context as a separated instance

### DIFF
--- a/src/flow_sql/base.py
+++ b/src/flow_sql/base.py
@@ -30,6 +30,7 @@ class BuildContext:
         self.json_dump_fn = json_dump_fn
 
     def set_param(self, value, json_stringify=False):
+        """Set a new (or update) query parameter."""
         while True:
             param_name = '{}{}'.format(self.param_name_prefix, self._params_next_idx)
             if param_name not in self.params:
@@ -204,12 +205,17 @@ class BaseCommand:
             params=ctx.params,
         )
 
+    # Argument `ctx` is unused here, but it is useful in derived classes.
+    # Given that I want to preserve its name here. That's why I suppress
+    # linter warning
+    # pylint: disable=W0613
     def _on_build_query(self, ctx):
         return sql.SQL('')
 
     def add_param(self, param_name, value, json_stringify=False):
         """Append a new parameter to the query."""
-        self._user_params[param_name] = _prepare_param_value(value, json_stringify, self.json_dump_fn)
+        self._user_params[param_name] = _prepare_param_value(
+            value, json_stringify, self.json_dump_fn)
         return self
 
     def add_params(self, params, json_stringify=False):
@@ -231,6 +237,7 @@ class BaseCommand:
         return self._user_params.copy()
 
     def build_subquery(self, subquery, ctx):
+        """Build a subquery regard to the current build context."""
         res = subquery.build_query(param_name_prefix='p{}_'.format(ctx.subqueries_built))
         for k, v in subquery.get_params().items():
             ctx.params[k] = v

--- a/src/flow_sql/command.py
+++ b/src/flow_sql/command.py
@@ -31,9 +31,5 @@ class Command(BaseCommand):
     def as_string(self):
         return self._sql
 
-    def build_query(self, param_name_prefix=None):
-        super().build_query(param_name_prefix)
+    def _on_build_query(self, ctx):
         return sql.SQL(self._sql)
-
-    def _set_param(self, value, json_stringify=False):
-        raise Exception('Unimplemented here. Use `add_param` instead')

--- a/src/flow_sql/copy_.py
+++ b/src/flow_sql/copy_.py
@@ -6,7 +6,7 @@ import json
 from collections.abc import Mapping, Iterable
 from io import StringIO
 
-from .base import BaseCommand
+from .base import BaseCommand, BuildContext
 
 
 class Copy:
@@ -34,9 +34,10 @@ class Copy:
         text = "\n".join(text)
         fh_output = StringIO(text)
         cmd = BaseCommand(self._conn)
+        ctx = BuildContext({}, {}, cmd.json_dump_fn)
         sql = "COPY {table}({columns}) FROM STDIN WITH DELIMITER '{sep}' NULL '{null}'".format(
-            table=cmd.quoted(self.table),
-            columns=','.join(cmd.quoted(c) for c in self.columns),
+            table=cmd.quote_string(self.table, ctx).as_string(self._conn),
+            columns=','.join(cmd.quote_string(c, ctx).as_string(self._conn) for c in self.columns),
             sep=self.sep,
             null=self.null,
         )

--- a/src/flow_sql/delete.py
+++ b/src/flow_sql/delete.py
@@ -33,23 +33,22 @@ class Delete(BaseCommand, WhereBehaviour, WithBehaviour, FromBehaviour, Returnin
         if where is not None:
             self.where(where)
 
-    def build_query(self, param_name_prefix=None):
-        super().build_query(param_name_prefix)
+    def _on_build_query(self, ctx):
         parts = [
-            self._build_query_with(),
+            self._build_query_with(ctx),
             sql.SQL('DELETE'),
-            self._build_query_from(),
-            self._build_query_where(),
-            self._build_query_returning(),
+            self._build_query_from(ctx),
+            self._build_query_where(ctx),
+            self._build_query_returning(ctx),
         ]
         res = sql.SQL(' ').join([p for p in parts if p is not None])
         return res
 
-    def _build_query_where(self):
+    def _build_query_where(self, ctx):
         incorrect_where = False
         if self._where in [None]:
             incorrect_where = True
         if incorrect_where:
             raise Exception(
                 'Sorry empty WHERE block is restricted on DELETE operations for security reasons')
-        return super()._build_query_where()
+        return super()._build_query_where(ctx)

--- a/src/flow_sql/query.py
+++ b/src/flow_sql/query.py
@@ -102,7 +102,7 @@ class Query(BaseCommand, WhereBehaviour, WithBehaviour, FromBehaviour):
             self._select.append(field)
         return self
 
-    def _join_table(self, join_type, table, on=None, alias=None, lateral=False):
+    def join_table(self, join_type, table, on=None, alias=None, lateral=False):
         """
         Add a new JOIN query block. There are following methods available:
         * `join_full` - for JOIN FULL
@@ -137,10 +137,11 @@ class Query(BaseCommand, WhereBehaviour, WithBehaviour, FromBehaviour):
         ))
         return self
 
-    join_left = functools.partialmethod(_join_table, JOIN_LEFT)
-    join_right = functools.partialmethod(_join_table, JOIN_RIGHT)
-    join_ = functools.partialmethod(_join_table, JOIN_INNER)
-    join_full = functools.partialmethod(_join_table, JOIN_FULL)
+    join_left = functools.partialmethod(join_table, JOIN_LEFT)
+    join_right = functools.partialmethod(join_table, JOIN_RIGHT)
+    join_ = functools.partialmethod(join_table, JOIN_INNER)
+    join_inner = functools.partialmethod(join_table, JOIN_INNER)
+    join_full = functools.partialmethod(join_table, JOIN_FULL)
 
     def group(self, fields):
         """
@@ -239,22 +240,21 @@ class Query(BaseCommand, WhereBehaviour, WithBehaviour, FromBehaviour):
         self._limit = limit
         return self
 
-    def build_query(self, param_name_prefix=None):
-        super().build_query(param_name_prefix)
+    def _on_build_query(self, ctx):
         parts = [
-            self._build_query_with(),
-            self._build_query_select(),
-            self._build_query_from(),
-            self._build_query_join(),
-            self._build_query_where(),
-            self._build_query_group(),
-            self._build_query_order(),
-            self._build_query_limit(),
+            self._build_query_with(ctx),
+            self._build_query_select(ctx),
+            self._build_query_from(ctx),
+            self._build_query_join(ctx),
+            self._build_query_where(ctx),
+            self._build_query_group(ctx),
+            self._build_query_order(ctx),
+            self._build_query_limit(ctx),
         ]
         res = sql.SQL(' ').join([p for p in parts if p is not None])
         return res
 
-    def _build_query_select(self):
+    def _build_query_select(self, ctx):
         prefix = sql.SQL('SELECT')
         if self._distinct:
             prefix = prefix + sql.SQL(' DISTINCT')
@@ -263,14 +263,14 @@ class Query(BaseCommand, WhereBehaviour, WithBehaviour, FromBehaviour):
 
         def build_field(field):
             if isinstance(field, const):
-                return self._o._set_param(field.value)
-            return self.quote_string(field)
+                return ctx.set_param(field.value)
+            return self.quote_string(field, ctx)
 
         return prefix + sql.SQL(' ') + (sql.SQL(', ').join([
             build_field(field) for field in self._select
         ]))
 
-    def _build_query_join(self):
+    def _build_query_join(self, ctx):
         if len(self._join) == 0:
             return None
         res = []
@@ -279,31 +279,31 @@ class Query(BaseCommand, WhereBehaviour, WithBehaviour, FromBehaviour):
             joined_items = sql.SQL('{join_type} JOIN{lateral} {table}').format(
                 join_type=sql.SQL(join_type),
                 lateral=sql.SQL(' LATERAL' if lateral else ''),
-                table=self.quote_string(table),
+                table=self.quote_string(table, ctx),
             )
             if on:
-                joined_items += sql.SQL(' ON ') + self._build_query_where_iter(on)
+                joined_items += sql.SQL(' ON ') + self._build_query_where_iter(on, ctx)
             res.append(joined_items)
         return sql.SQL(' ').join(res)
 
-    def _build_query_group(self):
+    def _build_query_group(self, ctx):
         if len(self._group) == 0:
             return None
         return sql.SQL('GROUP BY ') + (sql.SQL(', ').join([
-            self.quote_string(field) for field in self._group
+            self.quote_string(field, ctx) for field in self._group
         ]))
 
-    def _build_query_order(self):
+    def _build_query_order(self, ctx):
         if len(self._order) == 0:
             return None
         return sql.SQL('ORDER BY ') + (sql.SQL(', ').join([
             sql.SQL('{}{}').format(
-                self.quote_string(o.ident),
+                self.quote_string(o.ident, ctx),
                 sql.SQL(' ' + o.sort if o.sort else ''),
             ) for o in self._order
         ]))
 
-    def _build_query_limit(self) -> sql.Composable:
+    def _build_query_limit(self, ctx):
         return sql.SQL('LIMIT {}').format(sql.Literal(self._limit)) if self._limit else None
 
 

--- a/src/flow_sql/query.py
+++ b/src/flow_sql/query.py
@@ -249,7 +249,7 @@ class Query(BaseCommand, WhereBehaviour, WithBehaviour, FromBehaviour):
             self._build_query_where(ctx),
             self._build_query_group(ctx),
             self._build_query_order(ctx),
-            self._build_query_limit(ctx),
+            self._build_query_limit(),
         ]
         res = sql.SQL(' ').join([p for p in parts if p is not None])
         return res
@@ -303,7 +303,7 @@ class Query(BaseCommand, WhereBehaviour, WithBehaviour, FromBehaviour):
             ) for o in self._order
         ]))
 
-    def _build_query_limit(self, ctx):
+    def _build_query_limit(self):
         return sql.SQL('LIMIT {}').format(sql.Literal(self._limit)) if self._limit else None
 
 

--- a/src/flow_sql/update.py
+++ b/src/flow_sql/update.py
@@ -92,39 +92,38 @@ class Update(BaseCommand, WhereBehaviour, WithBehaviour, ReturningBehaviour, Tab
         self._fields[field] = value
         return self
 
-    def build_query(self, param_name_prefix=None):
-        super().build_query(param_name_prefix)
+    def _on_build_query(self, ctx):
         parts = [
-            self._build_query_with(),
-            self._build_query_update(),
-            self._build_query_set(),
-            self._build_query_where(),
-            self._build_query_returning(),
+            self._build_query_with(ctx),
+            self._build_query_update(ctx),
+            self._build_query_set(ctx),
+            self._build_query_where(ctx),
+            self._build_query_returning(ctx),
         ]
         res = sql.SQL(' ').join([p for p in parts if p is not None])
         return res
 
-    def _build_query_where(self):
+    def _build_query_where(self, ctx):
         incorrect_where = False
         if self._where in [None]:
             incorrect_where = True
         if incorrect_where:
             raise Exception('Sorry empty WHERE block is restricted on UPDATE operations. '
                             'Please call where(True) if you have to update all rows in the table')
-        return super()._build_query_where()
+        return super()._build_query_where(ctx)
 
-    def _build_query_update(self):
+    def _build_query_update(self, ctx):
         if not self._table:
             return None
-        res = sql.SQL('UPDATE ') + self.quote_string(self._table)
+        res = sql.SQL('UPDATE ') + self.quote_string(self._table, ctx)
         return res
 
-    def _build_query_set(self):
+    def _build_query_set(self, ctx):
         res = []
         for field, value in self._fields.items():
             res.append(sql.SQL('{field}={value}').format(
-                field=self.quote_string(field),
-                value=self._place_value(value),
+                field=self.quote_string(field, ctx),
+                value=self._place_value(value, ctx),
             ))
         if len(res) == 0:
             return None

--- a/tests/funcs.py
+++ b/tests/funcs.py
@@ -2,9 +2,11 @@ import itertools
 
 
 def assert_query(cmd, expected_query, expected_params):
-    actual_query = cmd.as_string()
+    built_cmd = cmd.build_query()
+    actual_query = built_cmd.as_string()
+    actual_params = built_cmd.params
     assert actual_query == expected_query, '"{}" != "{}"'.format(actual_query, expected_query)
-    assert cmd._params == expected_params, '"{}" != "{}"'.format(cmd._params, expected_params)
+    assert actual_params == expected_params, '"{}" != "{}"'.format(actual_params, expected_params)
 
 
 def create_table(conn, tablename, columns):


### PR DESCRIPTION
In order to make the code more readable and avoid global effects a new `BuildContext` class was introduced. It stores all temporary information about query building process. As a result of building now it will be returned a new `BuiltCommand` class. It incapsulated all logic of fetching data from the database. Backward compatibility with old API is preserved, so the PR doesn't break old code.